### PR TITLE
ENH: Harden the dwd version to 1.0.2

### DIFF
--- a/SlicerDWD/SlicerDWD.py
+++ b/SlicerDWD/SlicerDWD.py
@@ -34,6 +34,19 @@ if dwd.__version__ != DWD_VERSION:
     slicer.util.pip_install('dwd=={}'.format(DWD_VERSION))
     importlib.reload(dwd)
 
+    def request_restart():
+        if slicer.util.confirmYesNoDisplay(
+            'SlicerDWD has updated Python dependencies. '
+            'It is recommended to restart Slicer. Restart now?'
+        ):
+            slicer.util.restart()
+            slicer.util.exit()
+
+    slicer.app.startupCompleted.connect(
+        # need to use a singeShot timer so confirmYesNoDisplay has a valid QT context.
+        lambda: qt.QTimer.singleShot(0, request_restart)
+    )
+
 
 class SlicerDWD(ScriptedLoadableModule):
     """Uses ScriptedLoadableModule base class, available at:


### PR DESCRIPTION
Harden dwd installation to the current version (1.0.2)

Also checks if the currently-installed dwd is of an incorrect version. If so, it installs and reloads the module to get the correct version.

Resolves #7.